### PR TITLE
Update lib.c

### DIFF
--- a/thread/source/lib.c
+++ b/thread/source/lib.c
@@ -10,7 +10,7 @@ void *memset(void * ptr, int value, unsigned int num){
 }
 
 int strcomp(char* s1, char* s2, unsigned int size){
-	for(int i = 0; i < size; i++){
+	for(int i = 0; i < size*2; i++){	// doubling size brings this in line with strcopy() and fixes the "Rei" string randomly replacing "Ver" in other places.
         if(s1[i] != s2[i]) return 0;
     }
 	return 1;


### PR DESCRIPTION
Changed strcomp() to double the given size to bring it in line with strcopy(). Doing so stops "Rei" from replacing "Ver" in unintended places.
